### PR TITLE
Dev/stream token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 # Debug files
 *.dSYM/
 *.su
+build/

--- a/examples/token.c
+++ b/examples/token.c
@@ -1,0 +1,105 @@
+#include "../jsmn_stream_token.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * A small example of jsmn-stream token parsing when the JSON structure is known and number of
+ * tokens is predictable.
+ * 
+ * Say you are using an embedded system and cannot fit all of the JSON in memory.
+ */
+
+#define MAX_TOKENS (32U)
+#define MAX_BUFFER_SIZE (16U)
+
+const char *json_data =
+    "{"
+        "\"user\": \"johndoe\", "
+        "\"admin\": false, "
+        "\"uid\": 1000,"
+        "\"groups\": ["
+            "\"users\", "
+            "\"wheel\", "
+            "\"audio\", "
+            "\"video\""
+        "]"
+    "}";
+
+/**
+ * @brief Pretend to you have a big file in flash or you are reading over a network.
+ * 
+ * @param start_index 
+ * @param size 
+ * @param buffer 
+ */
+void pretend_to_read_a_file(int start_index, int size, char *buffer)
+{
+    for (int i = 0; i < size; i++)
+    {
+        buffer[i] = json_data[start_index + i];
+    }
+}
+
+int main(void)
+{
+    jsmn_stream_token_parser_t token_parser = {0};
+    jsmn_streamtok_t tokens[MAX_TOKENS] = {0};
+    int json_size = strlen(json_data);
+
+    jsmn_stream_parse_tokens_init(&token_parser, tokens, MAX_TOKENS);
+
+    // Get your tokens first.
+    for (int i = 0; i < json_size; i++)
+    { 
+        char byte = 0;
+        pretend_to_read_a_file(i, 1, &byte);
+
+        if (jsmn_stream_parse_tokens(&token_parser, byte) != JSMN_STREAM_TOKEN_ERROR_NONE)
+        {
+            return 1;
+        }
+    }
+
+    // Now you can use the tokens to get smaller chunks of data.
+    for (int i = 0; i < MAX_TOKENS; i++)
+    {
+        char buffer[MAX_BUFFER_SIZE] = {0};
+        int length = tokens[i].end - tokens[i].start;
+
+        if (length < MAX_BUFFER_SIZE)
+        {
+            pretend_to_read_a_file(tokens[i].start, length, buffer);
+
+            if (tokens[i].type == JSMN_STREAM_KEY)
+            {
+                // check if this is the key you are looking for.
+            }
+            else if (tokens[i].type == JSMN_STREAM_STRING)
+            {
+                // do something with the string.
+            }
+            else if (tokens[i].type == JSMN_STREAM_PRIMITIVE)
+            {
+                // check if it is boolean or numeric
+                bool bool_value = false;
+                double double_value = 0.0;
+
+                if (strcasecmp(buffer, "true") == 0)
+                {
+                    bool_value = true;
+                }
+                else if (strcasecmp(buffer, "false") == 0)
+                {
+                    bool_value = false;
+                }
+                else
+                {
+                    double_value = strtod(buffer, NULL);
+                }
+            }
+        }
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/examples/token.c
+++ b/examples/token.c
@@ -27,10 +27,10 @@ const char *json_data =
     "}";
 
 /**
- * @brief Pretend to you have a big file in flash or you are reading over a network.
+ * @brief Pretend that you have a big file in flash or you are reading over a network.
  * 
  * @param start_index 
- * @param size 
+ * @param size in bytes
  * @param buffer 
  */
 void pretend_to_read_a_file(int start_index, int size, char *buffer)

--- a/jsmn_stream.c
+++ b/jsmn_stream.c
@@ -4,7 +4,6 @@
  */
 
 #include "jsmn_stream.h"
-
 #include <stdbool.h>
 
 #define JSMN_STREAM_CALLBACK(f, ...) if ((f) != NULL) { (f)(__VA_ARGS__); }
@@ -219,4 +218,3 @@ void jsmn_stream_init(jsmn_stream_parser *parser,
 	parser->callbacks = *callbacks;
 	parser->user_arg = user_arg;
 }
-

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -11,7 +11,7 @@ static void jsmn_stream_parse_tokens_end_object(void *user_arg);
 static void jsmn_stream_parse_tokens_object_key(const char *key, size_t key_length, void *user_arg);
 static void jsmn_stream_parse_tokens_string(const char *value, size_t length, void *user_arg);
 static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length, void *user_arg);
-
+	
 static jsmn_stream_callbacks_t jsmn_stream_token_callbacks = {
 	.start_array_callback = jsmn_stream_parse_tokens_start_array,
 	.end_array_callback = jsmn_stream_parse_tokens_end_array,
@@ -24,20 +24,21 @@ static jsmn_stream_callbacks_t jsmn_stream_token_callbacks = {
 
 /**
  * @brief Initialize the jsmn_stream_token_parser_t object.
+ * 	This in turn initializes the regular jsmn_stream_parser
  * 
- * @param jsmn_stream_parser 
+ * @param jsmn_stream_token_parser 
  * @param tokens 
  * @param num_tokens 
  */
-void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_parser, jsmn_streamtok_t *tokens, int num_tokens)
+void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_token_parser, jsmn_streamtok_t *tokens, int num_tokens)
 {
-	jsmn_stream_parser->tokens = tokens;
-	jsmn_stream_parser->num_tokens = num_tokens;
-	jsmn_stream_parser->next_token = 0;
-	jsmn_stream_parser->char_count = 0;
-	jsmn_stream_parser->super_token_id = JSMN_STREAM_TOKEN_UNDEFINED;
-	jsmn_stream_parser->error = JSMN_STREAM_TOKEN_ERROR_NONE;
-	jsmn_stream_init(&jsmn_stream_parser->stream_parser, &jsmn_stream_token_callbacks, jsmn_stream_parser);
+	jsmn_stream_token_parser->tokens = tokens;
+	jsmn_stream_token_parser->num_tokens = num_tokens;
+	jsmn_stream_token_parser->next_token = 0;
+	jsmn_stream_token_parser->char_count = 0;
+	jsmn_stream_token_parser->super_token_id = JSMN_STREAM_TOKEN_UNDEFINED;
+	jsmn_stream_token_parser->error = JSMN_STREAM_TOKEN_ERROR_NONE;
+	jsmn_stream_init(&jsmn_stream_token_parser->stream_parser, &jsmn_stream_token_callbacks, jsmn_stream_token_parser);
 
 	for (uint32_t i = 0; i < (uint32_t)num_tokens; i++)
 	{

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -108,7 +108,6 @@ static jsmn_streamtok_t *jsmn_stream_get_super_token(jsmn_stream_token_parser_t 
 	return &jsmn_stream_parser->tokens[jsmn_stream_parser->super_token_id];
 }
 
-
 /**
  * @brief Callback used when an array is started.
  * 

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -38,6 +38,17 @@ void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_parse
 	jsmn_stream_parser->super_token_id = JSMN_STREAM_TOKEN_UNDEFINED;
 	jsmn_stream_parser->error = JSMN_STREAM_TOKEN_ERROR_NONE;
 	jsmn_stream_init(&jsmn_stream_parser->stream_parser, &jsmn_stream_token_callbacks, jsmn_stream_parser);
+
+	for (uint32_t i = 0; i < (uint32_t)num_tokens; i++)
+	{
+		jsmn_streamtok_t *token = &tokens[i];
+		token->id = i;
+		token->type = JSMN_STREAM_UNDEFINED;
+		token->start = JSMN_STREAM_POSITION_UNDEFINED;
+		token->end = JSMN_STREAM_POSITION_UNDEFINED;
+		token->size = 0;
+		token->parent_id = JSMN_STREAM_TOKEN_UNDEFINED;
+	}
 }
 
 /**

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -1,215 +1,15 @@
 #include "jsmn_stream_token.h"
 #include <stdbool.h>
 
-
-static jsmn_streamtok_t *jsmn_stream_allocate_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
-{
-	jsmn_streamtok_t *token;
-
-	if (jsmn_stream_parser->next_token >= jsmn_stream_parser->num_tokens)
-	{
-		jsmn_stream_parser->error = JSMN_STREAM_ERROR_NOMEM;
-		return NULL;
-	}
-
-	token = &jsmn_stream_parser->tokens[jsmn_stream_parser->next_token++];
-	token->type = JSMN_STREAM_UNDEFINED;
-	token->start = -1;
-	token->end = -1;
-	token->size = 0;
-	token->parent = jsmn_stream_parser->toksuper;
-	return token;
-}
-
-static jsmn_streamtok_t *jsmn_stream_get_super_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
-{
-	return &jsmn_stream_parser->tokens[jsmn_stream_parser->toksuper];
-}
-
-static void jsmn_stream_parse_tokens_start_array(void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// update the parent size
-	if (jsmn_stream_parser->toksuper != -1)
-	{
-		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
-		parent->size++;
-		token->parent = jsmn_stream_parser->toksuper;
-	}
-
-	token->type = JSMN_STREAM_ARRAY;
-	token->start = jsmn_stream_parser->char_count - 1;
-
-	// make this the new super token
-	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
-}
-
-
-static void jsmn_stream_parse_tokens_end_array(void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// step back to the start of the array
-	while (token->parent > -1 && token->type != JSMN_STREAM_ARRAY)
-	{
-		token = &jsmn_stream_parser->tokens[token->parent];
-	}
-	
-	token->end = jsmn_stream_parser->char_count; 
-
-	// make the parent the new super token
-	jsmn_stream_parser->toksuper = token->parent;
-
-}
-
-static void jsmn_stream_parse_tokens_start_object(void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// update the parent size
-	if (jsmn_stream_parser->toksuper != -1)
-	{
-		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
-		parent->size++;
-		token->parent = jsmn_stream_parser->toksuper;
-	}
-
-	token->type = JSMN_STREAM_OBJECT;
-	token->start = jsmn_stream_parser->char_count - 1; 
-
-	// make this the new super token
-	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
-}
-
-static void jsmn_stream_parse_tokens_end_object(void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	int super_token_id = 0;
-	while ((token->parent > -1) && (token->type != JSMN_STREAM_OBJECT))
-	{
-		super_token_id = token->parent;
-		token = &jsmn_stream_parser->tokens[token->parent];
-		if (token->type == JSMN_STREAM_OBJECT)
-		{
-			break;
-		}
-	}
-	token->end = jsmn_stream_parser->char_count;
-
-	// make the parent the new super token
-	jsmn_stream_parser->toksuper = super_token_id;
-}
-
-static void jsmn_stream_parse_tokens_object_key(const char *key, size_t key_length, void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// update the parent size
-	if (jsmn_stream_parser->toksuper != -1)
-	{
-		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
-		parent->size++;
-		token->parent = jsmn_stream_parser->toksuper;
-	}
-
-	token->type = JSMN_STREAM_KEY;
-	token->start = jsmn_stream_parser->char_count - key_length - 1;
-	token->end = jsmn_stream_parser->char_count - 1;
-	token->size = 0;
-
-	// make this the new super token
-	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
-}
-
-static void jsmn_stream_parse_tokens_string(const char *value, size_t length, void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// update the parent size
-	if (jsmn_stream_parser->toksuper != -1)
-	{
-		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
-		parent->size++;
-		token->parent = jsmn_stream_parser->toksuper;
-	}
-
-	token->type = JSMN_STREAM_STRING;
-	token->start = jsmn_stream_parser->char_count - length - 1;
-	token->end = jsmn_stream_parser->char_count - 1;
-	token->size = 0;
-
-	// make the super token the last object or array
-	while (token->type != JSMN_STREAM_OBJECT && token->type != JSMN_STREAM_ARRAY)
-	{
-		token = &jsmn_stream_parser->tokens[token->parent];
-	}
-	jsmn_stream_parser->toksuper = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
-}
-
-static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length, void *user_arg)
-{
-	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
-	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
-
-	if (token == NULL)
-	{
-		return;
-	}
-
-	// update the parent size
-	if (jsmn_stream_parser->toksuper != -1)
-	{
-		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
-		parent->size++;
-		token->parent = jsmn_stream_parser->toksuper;
-	}
-
-	token->type = JSMN_STREAM_PRIMITIVE;
-	token->start = jsmn_stream_parser->char_count - length - 1;
-	token->end = jsmn_stream_parser->char_count - 1;
-	token->size = length;
-
-	// make the parent's parent the new super token
-	jsmn_stream_parser->toksuper = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
-}
+static jsmn_streamtok_t *jsmn_stream_allocate_token(jsmn_stream_token_parser_t *jsmn_stream_parser);
+static jsmn_streamtok_t *jsmn_stream_get_super_token(jsmn_stream_token_parser_t *jsmn_stream_parser);
+static void jsmn_stream_parse_tokens_start_array(void *user_arg);
+static void jsmn_stream_parse_tokens_end_array(void *user_arg);
+static void jsmn_stream_parse_tokens_start_object(void *user_arg);
+static void jsmn_stream_parse_tokens_end_object(void *user_arg);
+static void jsmn_stream_parse_tokens_object_key(const char *key, size_t key_length, void *user_arg);
+static void jsmn_stream_parse_tokens_string(const char *value, size_t length, void *user_arg);
+static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length, void *user_arg);
 
 static jsmn_stream_callbacks_t jsmn_stream_token_callbacks = {
 	.start_array_callback = jsmn_stream_parse_tokens_start_array,
@@ -221,28 +21,273 @@ static jsmn_stream_callbacks_t jsmn_stream_token_callbacks = {
 	.primitive_callback = jsmn_stream_parse_tokens_primitive
 };
 
+/**
+ * @brief Initialize the jsmn_stream_token_parser_t object.
+ * 
+ * @param jsmn_stream_parser 
+ * @param tokens 
+ * @param num_tokens 
+ */
 void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_parser, jsmn_streamtok_t *tokens, int num_tokens)
 {
 	jsmn_stream_parser->tokens = tokens;
 	jsmn_stream_parser->num_tokens = num_tokens;
 	jsmn_stream_parser->next_token = 0;
 	jsmn_stream_parser->char_count = 0;
-	jsmn_stream_parser->toksuper = -1;
+	jsmn_stream_parser->super_token_id = JSMN_STREAM_TOKEN_UNDEFINED;
 	jsmn_stream_parser->error = JSMN_STREAM_TOKEN_ERROR_NONE;
 	jsmn_stream_init(&jsmn_stream_parser->stream_parser, &jsmn_stream_token_callbacks, jsmn_stream_parser);
 }
 
+/**
+ * @brief Parse a character.
+ * 
+ * @param jsmn_stream_parser 
+ * @param c 
+ * @return int 
+ */
 int jsmn_stream_parse_tokens(jsmn_stream_token_parser_t *jsmn_stream_token_parser, char c)
 {
 	jsmn_stream_token_parser->char_count++;
 	jsmn_stream_parse((jsmn_stream_parser *)&jsmn_stream_token_parser->stream_parser , c);	
 
-	if (jsmn_stream_token_parser->error != JSMN_STREAM_TOKEN_ERROR_NONE)
-	{
-		return jsmn_stream_token_parser->error;
-	}
-
-	return 0;
+	return jsmn_stream_token_parser->error;
 }
 
+/**
+ * @brief Allocate a new token from the token pool.
+ * 
+ * @param jsmn_stream_parser 
+ * @return jsmn_streamtok_t* 
+ */
+static jsmn_streamtok_t *jsmn_stream_allocate_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
+{
+	jsmn_streamtok_t *token;
+
+	// if we are out of tokens, set the error and return NULL
+	if (jsmn_stream_parser->next_token >= jsmn_stream_parser->num_tokens)
+	{
+		jsmn_stream_parser->error = JSMN_STREAM_ERROR_NOMEM;
+		return NULL;
+	}
+
+	token = &jsmn_stream_parser->tokens[jsmn_stream_parser->next_token++];
+	token->type = JSMN_STREAM_UNDEFINED;
+	token->start = JSMN_STREAM_POSITION_UNDEFINED;
+	token->end = JSMN_STREAM_POSITION_UNDEFINED;
+	token->size = 0;
+	token->parent = jsmn_stream_parser->super_token_id;
+
+	// increment the size of the super token, unless it is the root token
+	if (token->parent != JSMN_STREAM_TOKEN_UNDEFINED)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		if (parent != NULL)
+		{
+			parent->size++;
+		}
+	}
+
+	return token;
+}
+
+/**
+ * @brief Get the super token object or array.
+ * 
+ * @param jsmn_stream_parser 
+ * @return jsmn_streamtok_t* 
+ */
+static jsmn_streamtok_t *jsmn_stream_get_super_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
+{
+	if (jsmn_stream_parser->super_token_id == JSMN_STREAM_TOKEN_UNDEFINED)
+	{
+		jsmn_stream_parser->error = JSMN_STREAM_TOKEN_ERROR_INVALID;
+		return NULL;
+	}
+
+	return &jsmn_stream_parser->tokens[jsmn_stream_parser->super_token_id];
+}
+
+
+/**
+ * @brief Callback used when an array is started.
+ * 
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_start_array(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	token->type = JSMN_STREAM_ARRAY;
+	token->start = jsmn_stream_parser->char_count - 1;
+
+	// make this the new super token
+	jsmn_stream_parser->super_token_id = jsmn_stream_parser->next_token - 1;
+}
+
+/**
+ * @brief Callback used when an array is ended.
+ * 
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_end_array(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
+	int super_token_id = 0;
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// the super token points to the last thing in the array
+	// step back until we find the start of the array
+	while ((token->parent > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_ARRAY))
+	{
+		super_token_id = token->parent;
+		token = &jsmn_stream_parser->tokens[token->parent];
+	}
+	
+	token->end = jsmn_stream_parser->char_count; 
+
+	// make the parent of the array the new super token
+	jsmn_stream_parser->super_token_id = super_token_id;
+}
+
+/**
+ * @brief Callback used when an object is started.
+ * 
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_start_object(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	token->type = JSMN_STREAM_OBJECT;
+	token->start = jsmn_stream_parser->char_count - 1; 
+
+	// make this the new super token
+	jsmn_stream_parser->super_token_id = jsmn_stream_parser->next_token - 1;
+}
+
+/**
+ * @brief Callback used when an object is ended.
+ * 
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_end_object(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
+	int super_token_id = 0;
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// the super token points to the last thing in the object
+	// step back until we find the start of the object
+	while ((token->parent > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_OBJECT))
+	{
+		super_token_id = token->parent;
+		token = &jsmn_stream_parser->tokens[token->parent];
+	}
+
+	token->end = jsmn_stream_parser->char_count;
+
+	// make the parent the new super token
+	jsmn_stream_parser->super_token_id = super_token_id;
+}
+
+/**
+ * @brief Callback used when an object key is parsed.
+ * 
+ * @param key is a pointer to the key string.
+ * @param key_length is the length of the key string.
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_object_key(const char *key, size_t key_length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	token->type = JSMN_STREAM_KEY;
+	token->start = jsmn_stream_parser->char_count - key_length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = 0;
+
+	// make this the new super token
+	jsmn_stream_parser->super_token_id = jsmn_stream_parser->next_token - 1;
+}
+
+/**
+ * @brief Callback used when a string is parsed.
+ * 
+ * @param value is a pointer to the string.
+ * @param length is the length of the string.
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_string(const char *value, size_t length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	token->type = JSMN_STREAM_STRING;
+	token->start = jsmn_stream_parser->char_count - length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = 0;
+
+	// make the parent's (a key) parent (object or array) the new super token
+	jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+}
+
+/**
+ * @brief Callback used when a primitive (number, bool, null) is parsed.
+ * 
+ * @param value is a pointer to the primitive.
+ * @param length is the length of the primitive.
+ * @param user_arg is a pointer to the jsmn_stream_token_parser_t object.
+ */
+static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	token->type = JSMN_STREAM_PRIMITIVE;
+	token->start = jsmn_stream_parser->char_count - length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = length;
+
+	// make the parent's (a key) parent (object or array) the new super token
+	jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+}
 

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -71,15 +71,17 @@ static jsmn_streamtok_t *jsmn_stream_allocate_token(jsmn_stream_token_parser_t *
 		return NULL;
 	}
 
-	token = &jsmn_stream_parser->tokens[jsmn_stream_parser->next_token++];
+	token = &jsmn_stream_parser->tokens[jsmn_stream_parser->next_token];
+	token->id = jsmn_stream_parser->next_token;
+	jsmn_stream_parser->next_token++;
 	token->type = JSMN_STREAM_UNDEFINED;
 	token->start = JSMN_STREAM_POSITION_UNDEFINED;
 	token->end = JSMN_STREAM_POSITION_UNDEFINED;
 	token->size = 0;
-	token->parent = jsmn_stream_parser->super_token_id;
+	token->parent_id = jsmn_stream_parser->super_token_id;
 
 	// increment the size of the super token, unless it is the root token
-	if (token->parent != JSMN_STREAM_TOKEN_UNDEFINED)
+	if (token->parent_id != JSMN_STREAM_TOKEN_UNDEFINED)
 	{
 		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
 		if (parent != NULL)
@@ -143,10 +145,10 @@ static void jsmn_stream_parse_tokens_end_array(void *user_arg)
 	{
 		// the super token points to the last thing in the array
 		// step back until we find the start of the array
-		while ((token->parent > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_ARRAY))
+		while ((token->parent_id > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_ARRAY))
 		{
-			super_token_id = token->parent;
-			token = &jsmn_stream_parser->tokens[token->parent];
+			super_token_id = token->parent_id;
+			token = &jsmn_stream_parser->tokens[token->parent_id];
 		}
 		
 		token->end = jsmn_stream_parser->char_count; 
@@ -191,10 +193,10 @@ static void jsmn_stream_parse_tokens_end_object(void *user_arg)
 	{
 		// the super token points to the last thing in the object
 		// step back until we find the start of the object
-		while ((token->parent > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_OBJECT))
+		while ((token->parent_id > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_OBJECT))
 		{
-			super_token_id = token->parent;
-			token = &jsmn_stream_parser->tokens[token->parent];
+			super_token_id = token->parent_id;
+			token = &jsmn_stream_parser->tokens[token->parent_id];
 		}
 
 		token->end = jsmn_stream_parser->char_count;
@@ -248,7 +250,7 @@ static void jsmn_stream_parse_tokens_string(const char *value, size_t length, vo
 		token->size = 0;
 
 		// make the parent's (a key) parent (object or array) the new super token
-		jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+		jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent_id;
 	}
 }
 
@@ -272,7 +274,7 @@ static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length,
 		token->size = length;
 
 		// make the parent's (a key) parent (object or array) the new super token
-		jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+		jsmn_stream_parser->super_token_id = jsmn_stream_get_super_token(jsmn_stream_parser)->parent_id;
 	}
 }
 

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -139,11 +139,11 @@ static void jsmn_stream_parse_tokens_end_array(void *user_arg)
 {
 	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
 	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
-	int super_token_id = 0;
 
 	if (token != NULL)
 	{
-		// the super token points to the last thing in the array
+		int super_token_id = token->parent_id;
+		// If the current super token is not pointing at the start of the array
 		// step back until we find the start of the array
 		while ((token->parent_id > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_ARRAY))
 		{
@@ -187,12 +187,13 @@ static void jsmn_stream_parse_tokens_end_object(void *user_arg)
 {
 	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
 	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
-	int super_token_id = 0;
 
 	if (token != NULL)
 	{
-		// the super token points to the last thing in the object
-		// step back until we find the start of the object
+		int super_token_id = token->parent_id;
+
+		// If the current super token is not pointing at the start of the object
+		// step back until we find it
 		while ((token->parent_id > JSMN_STREAM_TOKEN_UNDEFINED) && (token->type != JSMN_STREAM_OBJECT))
 		{
 			super_token_id = token->parent_id;

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -1,0 +1,248 @@
+#include "jsmn_stream_token.h"
+#include <stdbool.h>
+
+
+static jsmn_streamtok_t *jsmn_stream_allocate_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
+{
+	jsmn_streamtok_t *token;
+
+	if (jsmn_stream_parser->next_token >= jsmn_stream_parser->num_tokens)
+	{
+		jsmn_stream_parser->error = JSMN_STREAM_ERROR_NOMEM;
+		return NULL;
+	}
+
+	token = &jsmn_stream_parser->tokens[jsmn_stream_parser->next_token++];
+	token->type = JSMN_STREAM_UNDEFINED;
+	token->start = -1;
+	token->end = -1;
+	token->size = 0;
+	token->parent = jsmn_stream_parser->toksuper;
+	return token;
+}
+
+static jsmn_streamtok_t *jsmn_stream_get_super_token(jsmn_stream_token_parser_t *jsmn_stream_parser)
+{
+	return &jsmn_stream_parser->tokens[jsmn_stream_parser->toksuper];
+}
+
+static void jsmn_stream_parse_tokens_start_array(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// update the parent size
+	if (jsmn_stream_parser->toksuper != -1)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		parent->size++;
+		token->parent = jsmn_stream_parser->toksuper;
+	}
+
+	token->type = JSMN_STREAM_ARRAY;
+	token->start = jsmn_stream_parser->char_count - 1;
+
+	// make this the new super token
+	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
+}
+
+
+static void jsmn_stream_parse_tokens_end_array(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// step back to the start of the array
+	while (token->parent > -1 && token->type != JSMN_STREAM_ARRAY)
+	{
+		token = &jsmn_stream_parser->tokens[token->parent];
+	}
+	
+	token->end = jsmn_stream_parser->char_count; 
+
+	// make the parent the new super token
+	jsmn_stream_parser->toksuper = token->parent;
+
+}
+
+static void jsmn_stream_parse_tokens_start_object(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// update the parent size
+	if (jsmn_stream_parser->toksuper != -1)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		parent->size++;
+		token->parent = jsmn_stream_parser->toksuper;
+	}
+
+	token->type = JSMN_STREAM_OBJECT;
+	token->start = jsmn_stream_parser->char_count - 1; 
+
+	// make this the new super token
+	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
+}
+
+static void jsmn_stream_parse_tokens_end_object(void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_get_super_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	int super_token_id = 0;
+	while ((token->parent > -1) && (token->type != JSMN_STREAM_OBJECT))
+	{
+		super_token_id = token->parent;
+		token = &jsmn_stream_parser->tokens[token->parent];
+		if (token->type == JSMN_STREAM_OBJECT)
+		{
+			break;
+		}
+	}
+	token->end = jsmn_stream_parser->char_count;
+
+	// make the parent the new super token
+	jsmn_stream_parser->toksuper = super_token_id;
+}
+
+static void jsmn_stream_parse_tokens_object_key(const char *key, size_t key_length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// update the parent size
+	if (jsmn_stream_parser->toksuper != -1)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		parent->size++;
+		token->parent = jsmn_stream_parser->toksuper;
+	}
+
+	token->type = JSMN_STREAM_KEY;
+	token->start = jsmn_stream_parser->char_count - key_length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = 0;
+
+	// make this the new super token
+	jsmn_stream_parser->toksuper = jsmn_stream_parser->next_token - 1;
+}
+
+static void jsmn_stream_parse_tokens_string(const char *value, size_t length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// update the parent size
+	if (jsmn_stream_parser->toksuper != -1)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		parent->size++;
+		token->parent = jsmn_stream_parser->toksuper;
+	}
+
+	token->type = JSMN_STREAM_STRING;
+	token->start = jsmn_stream_parser->char_count - length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = 0;
+
+	// make the super token the last object or array
+	while (token->type != JSMN_STREAM_OBJECT && token->type != JSMN_STREAM_ARRAY)
+	{
+		token = &jsmn_stream_parser->tokens[token->parent];
+	}
+	jsmn_stream_parser->toksuper = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+}
+
+static void jsmn_stream_parse_tokens_primitive(const char *value, size_t length, void *user_arg)
+{
+	jsmn_stream_token_parser_t *jsmn_stream_parser = (jsmn_stream_token_parser_t *)user_arg;
+	jsmn_streamtok_t *token = jsmn_stream_allocate_token(jsmn_stream_parser);
+
+	if (token == NULL)
+	{
+		return;
+	}
+
+	// update the parent size
+	if (jsmn_stream_parser->toksuper != -1)
+	{
+		jsmn_streamtok_t *parent = jsmn_stream_get_super_token(jsmn_stream_parser);
+		parent->size++;
+		token->parent = jsmn_stream_parser->toksuper;
+	}
+
+	token->type = JSMN_STREAM_PRIMITIVE;
+	token->start = jsmn_stream_parser->char_count - length - 1;
+	token->end = jsmn_stream_parser->char_count - 1;
+	token->size = length;
+
+	// make the parent's parent the new super token
+	jsmn_stream_parser->toksuper = jsmn_stream_get_super_token(jsmn_stream_parser)->parent;
+}
+
+static jsmn_stream_callbacks_t jsmn_stream_token_callbacks = {
+	.start_array_callback = jsmn_stream_parse_tokens_start_array,
+	.end_array_callback = jsmn_stream_parse_tokens_end_array,
+	.start_object_callback = jsmn_stream_parse_tokens_start_object,
+	.end_object_callback = jsmn_stream_parse_tokens_end_object,
+	.object_key_callback = jsmn_stream_parse_tokens_object_key,
+	.string_callback = jsmn_stream_parse_tokens_string,
+	.primitive_callback = jsmn_stream_parse_tokens_primitive
+};
+
+void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_parser, jsmn_streamtok_t *tokens, int num_tokens)
+{
+	jsmn_stream_parser->tokens = tokens;
+	jsmn_stream_parser->num_tokens = num_tokens;
+	jsmn_stream_parser->next_token = 0;
+	jsmn_stream_parser->char_count = 0;
+	jsmn_stream_parser->toksuper = -1;
+	jsmn_stream_parser->error = JSMN_STREAM_TOKEN_ERROR_NONE;
+	jsmn_stream_init(&jsmn_stream_parser->stream_parser, &jsmn_stream_token_callbacks, jsmn_stream_parser);
+}
+
+int jsmn_stream_parse_tokens(jsmn_stream_token_parser_t *jsmn_stream_token_parser, char c)
+{
+	jsmn_stream_token_parser->char_count++;
+	jsmn_stream_parse((jsmn_stream_parser *)&jsmn_stream_token_parser->stream_parser , c);	
+
+	if (jsmn_stream_token_parser->error != JSMN_STREAM_TOKEN_ERROR_NONE)
+	{
+		return jsmn_stream_token_parser->error;
+	}
+
+	return 0;
+}
+
+

--- a/jsmn_stream_token.c
+++ b/jsmn_stream_token.c
@@ -152,7 +152,7 @@ static void jsmn_stream_parse_tokens_end_array(void *user_arg)
 		
 		token->end = jsmn_stream_parser->char_count; 
 
-		// make the parent of the array the new super token
+		// make the array the new super token
 		jsmn_stream_parser->super_token_id = super_token_id;
 	}
 }
@@ -200,7 +200,7 @@ static void jsmn_stream_parse_tokens_end_object(void *user_arg)
 
 		token->end = jsmn_stream_parser->char_count;
 
-		// make the parent the new super token
+		// make the object the new super token
 		jsmn_stream_parser->super_token_id = super_token_id;
 	}
 }

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -22,11 +22,12 @@ enum jsmn_stream_token_error {
  * 
  */
 typedef struct jsmn_streamtok {
+  int id; // token id. Useful when using pointers instead of array indexes
   jsmn_streamtype_t type;
   int start; // start position in the JSON data string
   int end; // end position in the JSON data string
   int size; // number of child (nested) tokens
-  int parent; // parent token index in the JSON data string
+  int parent_id; // parent token id in the JSON data string
 } jsmn_streamtok_t;
 
 typedef struct {

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -1,6 +1,7 @@
 #ifndef __JSMN_STREAM_TOKEN_H_
 #define __JSMN_STREAM_TOKEN_H_
 
+#include <stdint.h>
 #include <stdbool.h>
 #include "jsmn_stream.h"
 

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -8,20 +8,25 @@
 extern "C" {
 #endif
 
+#define JSMN_STREAM_TOKEN_UNDEFINED -1
+#define JSMN_STREAM_POSITION_UNDEFINED -1
+
 enum jsmn_stream_token_error {
   JSMN_STREAM_TOKEN_ERROR_NONE = 0,
   JSMN_STREAM_TOKEN_ERROR_NOMEM = -1,
-  JSMN_STREAM_TOKEN_ERROR_INVAL = -2,
-  JSMN_STREAM_TOKEN_ERROR_PART = -3,
-  JSMN_STREAM_TOKEN_ERROR_MAX = 0x7FFFFFFF
+  JSMN_STREAM_TOKEN_ERROR_INVALID = -2,
 };
 
+/**
+ * @brief
+ * 
+ */
 typedef struct jsmn_streamtok {
   jsmn_streamtype_t type;
-  int start;
-  int end;
-  int size;
-  int parent;
+  int start; // start position in the JSON data string
+  int end; // end position in the JSON data string
+  int size; // number of child (nested) tokens
+  int parent; // parent token index in the JSON data string
 } jsmn_streamtok_t;
 
 typedef struct {
@@ -30,7 +35,7 @@ typedef struct {
   int next_token;
   int num_tokens;
   int char_count;
-  int toksuper;
+  int super_token_id;
   int error;
 } jsmn_stream_token_parser_t;
 

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -31,6 +31,8 @@ typedef struct jsmn_streamtok {
   int parent_id; // parent token id in the JSON data string
 } jsmn_streamtok_t;
 
+typedef int32_t (*jsmn_stream_token_get_char_cb_t)(uint32_t index, size_t length, void *user_arg, char *ch);
+
 typedef struct {
   jsmn_stream_parser stream_parser;
   jsmn_streamtok_t *tokens;
@@ -39,6 +41,8 @@ typedef struct {
   int char_count;
   int super_token_id;
   int error;
+  jsmn_stream_token_get_char_cb_t cb;
+  void *user_arg;
 } jsmn_stream_token_parser_t;
 
 void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *tokens, int num_tokens);

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -1,0 +1,44 @@
+#ifndef __JSMN_STREAM_TOKEN_H_
+#define __JSMN_STREAM_TOKEN_H_
+
+#include <stdbool.h>
+#include "jsmn_stream.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum jsmn_stream_token_error {
+  JSMN_STREAM_TOKEN_ERROR_NONE = 0,
+  JSMN_STREAM_TOKEN_ERROR_NOMEM = -1,
+  JSMN_STREAM_TOKEN_ERROR_INVAL = -2,
+  JSMN_STREAM_TOKEN_ERROR_PART = -3,
+  JSMN_STREAM_TOKEN_ERROR_MAX = 0x7FFFFFFF
+};
+
+typedef struct jsmn_streamtok {
+  jsmn_streamtype_t type;
+  int start;
+  int end;
+  int size;
+  int parent;
+} jsmn_streamtok_t;
+
+typedef struct {
+  jsmn_stream_parser stream_parser;
+  jsmn_streamtok_t *tokens;
+  int next_token;
+  int num_tokens;
+  int char_count;
+  int toksuper;
+  int error;
+} jsmn_stream_token_parser_t;
+
+void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *tokens, int num_tokens);
+int jsmn_stream_parse_tokens(jsmn_stream_token_parser_t *parser, char c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __JSMN_STREAM_TOKEN_H_ */

--- a/jsmn_stream_token.h
+++ b/jsmn_stream_token.h
@@ -45,7 +45,7 @@ typedef struct {
   void *user_arg;
 } jsmn_stream_token_parser_t;
 
-void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *tokens, int num_tokens);
+void jsmn_stream_parse_tokens_init(jsmn_stream_token_parser_t *jsmn_stream_token_parser, jsmn_streamtok_t *tokens, int num_tokens);
 int jsmn_stream_parse_tokens(jsmn_stream_token_parser_t *parser, char c);
 
 #ifdef __cplusplus

--- a/jsmn_stream_token_utils.c
+++ b/jsmn_stream_token_utils.c
@@ -1,0 +1,179 @@
+#include "jsmn_stream_token_utils.h"
+#include <stdbool.h>
+#include <stdlib.h>
+
+static bool string_compare(const char *str1, const char *str2, size_t length);
+
+int32_t jsmn_stream_token_utils_parse_with_cb(jsmn_stream_token_parser_t *parser, jsmn_stream_token_get_char_cb_t get_char_cb, size_t length, void *user_arg)
+{
+    if ((parser == NULL) || (get_char_cb == NULL))
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    for (uint32_t i = 0U; i < (uint32_t)length; i++)
+    {
+        char ch;
+        if (get_char_cb(i, 1, user_arg, &ch) == JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE)
+        {
+            if (jsmn_stream_parse_tokens(parser, ch) != JSMN_STREAM_TOKEN_ERROR_NONE)
+            {
+                return parser->error;
+            }
+        }
+    }
+    return JSMN_STREAM_TOKEN_ERROR_NONE;
+}
+
+int32_t jsmn_stream_token_utils_array_get_next_object_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *array_token, jsmn_streamtok_t **iterator_token)
+{
+    jsmn_streamtok_t *token;
+    if (array_token == NULL)
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    if (*iterator_token == NULL)
+    {
+        *iterator_token = array_token;
+    }
+
+    token = *iterator_token;
+
+    while (token->id < parser->num_tokens)
+    {
+        token++;
+        if ((token->type == JSMN_STREAM_OBJECT)
+            && (token->parent_id == array_token->id))
+        {
+            *iterator_token = token;
+            return JSMN_STREAM_TOKEN_ERROR_NONE;
+        }
+    }
+
+    return JSMN_STREAM_TOKEN_UTILS_ERROR_OBJECT_NOT_FOUND;
+}
+
+int32_t jsmn_stream_token_utils_get_value_token_by_key(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *array_token, uint32_t num_tokens, const char *key, jsmn_streamtok_t **value_token)
+{
+    if ((get_char_cb == NULL) 
+        || (array_token == NULL) 
+        || (key == NULL)
+        || (value_token == NULL))
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    for (uint32_t i = 0; i < num_tokens; i++)
+    {
+        jsmn_streamtok_t *token = array_token + i;
+
+        if (token->type == JSMN_STREAM_KEY)
+		{
+            size_t string_length = (size_t)(token->end - token->start);
+            char buffer[string_length];
+
+            if (get_char_cb(token->start, string_length, user_arg, buffer) == JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE)
+            {
+                if (string_compare(buffer, key, string_length) == true)
+                {
+                    *value_token = token + 1;
+                    return JSMN_STREAM_TOKEN_ERROR_NONE;
+                }
+            }
+        }
+    }
+
+    return JSMN_STREAM_TOKEN_UTILS_ERROR_KEY_NOT_FOUND;
+}
+
+static bool string_compare(const char *str1, const char *str2, size_t length)
+{
+    for (uint32_t i = 0; i < length; i++)
+    {
+        if (str1[i] != str2[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int32_t jsmn_stream_token_utils_get_string_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token, char *buffer)
+{
+    if ((get_char_cb == NULL) 
+        || (token == NULL) 
+        || (buffer == NULL))
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    size_t string_length = (size_t)(token->end - token->start);
+    return get_char_cb(token->start, string_length, user_arg, buffer);
+}
+
+int32_t jsmn_stream_token_utils_get_int_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  int32_t *value)
+{
+     if ((get_char_cb == NULL) 
+        || (token == NULL))
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    size_t string_length = (size_t)(token->end - token->start);
+    char buffer[string_length];
+    if (get_char_cb(token->start, string_length, user_arg, buffer) == JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE)
+    {
+        *value = strtol(buffer, NULL, 10);
+        return JSMN_STREAM_TOKEN_ERROR_NONE;
+    }
+
+    return JSMN_STREAM_TOKEN_UTILS_ERROR_FAIL;
+}
+
+int32_t jsmn_stream_token_utils_get_double_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  double *value)
+{
+        if ((get_char_cb == NULL) 
+            || (token == NULL))
+        {
+            return JSMN_STREAM_TOKEN_ERROR_INVALID;
+        }
+    
+        size_t string_length = (size_t)(token->end - token->start);
+        char buffer[string_length];
+        if (get_char_cb(token->start, string_length, user_arg, buffer) == JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE)
+        {
+            *value = strtod(buffer, NULL);
+            return JSMN_STREAM_TOKEN_ERROR_NONE;
+        }
+    
+        return JSMN_STREAM_TOKEN_UTILS_ERROR_FAIL;
+}
+
+int32_t jsmn_stream_token_utils_get_bool_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  bool *value)
+{
+    if ((get_char_cb == NULL) 
+        || (token == NULL))
+    {
+        return JSMN_STREAM_TOKEN_ERROR_INVALID;
+    }
+
+    size_t string_length = (size_t)(token->end - token->start);
+    char buffer[string_length];
+    if (get_char_cb(token->start, string_length, user_arg, buffer) == JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE)
+    {
+        if (string_compare(buffer, "true", string_length) == true)
+        {
+            *value = true;
+            return JSMN_STREAM_TOKEN_ERROR_NONE;
+        }
+        else if (string_compare(buffer, "false", string_length) == true)
+        {
+            *value = false;
+            return JSMN_STREAM_TOKEN_ERROR_NONE;
+        }
+    }
+
+    return JSMN_STREAM_TOKEN_UTILS_ERROR_FAIL;
+}

--- a/jsmn_stream_token_utils.h
+++ b/jsmn_stream_token_utils.h
@@ -25,15 +25,18 @@ enum jsmn_stream_token_utils_error
     JSMN_STREAM_TOKEN_UTILS_ERROR_OBJECT_NOT_FOUND = -4,
 };
 
-typedef int32_t (*jsmn_stream_token_get_char_cb_t)(uint32_t index, size_t length, void *user_arg, char *ch);
 
-int32_t jsmn_stream_token_utils_parse_with_cb(jsmn_stream_token_parser_t *parser, jsmn_stream_token_get_char_cb_t get_char_cb, size_t length, void *user_arg);
-int32_t jsmn_stream_token_utils_get_value_token_by_key(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *parent, uint32_t num_tokens, const char *key, jsmn_streamtok_t **value_token);
+int32_t jsmn_stream_token_utils_parse_with_cb(jsmn_stream_token_parser_t *parser, size_t length, void *user_arg);
+int32_t jsmn_stream_token_utils_get_value_token_by_key(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, const char *key, jsmn_streamtok_t **value_token);
 int32_t jsmn_stream_token_utils_array_get_next_object_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, jsmn_streamtok_t **iterator_token);
-int32_t jsmn_stream_token_utils_get_string_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token, char *buffer);
-int32_t jsmn_stream_token_utils_get_int_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  int32_t *value);
-int32_t jsmn_stream_token_utils_get_double_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  double *value);
-int32_t jsmn_stream_token_utils_get_bool_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  bool *value);
+int32_t jsmn_stream_token_utils_get_string_from_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *token, char *buffer);
+int32_t jsmn_stream_token_utils_get_string_by_key(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, const char *key, char *buffer);
+int32_t jsmn_stream_token_utils_get_int_from_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *token, int32_t *value);
+int32_t jsmn_stream_token_utils_get_int_by_key(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, const char *key, int32_t *value);
+int32_t jsmn_stream_token_utils_get_double_from_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *token, double *value);
+int32_t jsmn_stream_token_utils_get_double_by_key(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, const char *key, double *value);
+int32_t jsmn_stream_token_utils_get_bool_from_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *token, bool *value);
+int32_t jsmn_stream_token_utils_get_bool_by_key(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, const char *key, bool *value);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/jsmn_stream_token_utils.h
+++ b/jsmn_stream_token_utils.h
@@ -1,0 +1,42 @@
+#ifndef JSMN_STREAM_TOKEN_UTILS_H_
+#define JSMN_STREAM_TOKEN_UTILS_H_
+
+#include <stdint.h>
+#include "jsmn_stream.h"
+#include "jsmn_stream_token.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+enum jsmn_stream_token_get_char_cb_error
+{
+    JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_NONE = 0,
+    JSMN_STREAM_TOKEN_GET_CHAR_CB_ERROR_FAIL = -1,
+};
+
+enum jsmn_stream_token_utils_error
+{
+    JSMN_STREAM_TOKEN_UTILS_ERROR_NONE = 0,
+    JSMN_STREAM_TOKEN_UTILS_ERROR_FAIL = -1,
+    JSMN_STREAM_TOKEN_UTILS_ERROR_INVALID = -2,
+    JSMN_STREAM_TOKEN_UTILS_ERROR_KEY_NOT_FOUND = -3,
+    JSMN_STREAM_TOKEN_UTILS_ERROR_OBJECT_NOT_FOUND = -4,
+};
+
+typedef int32_t (*jsmn_stream_token_get_char_cb_t)(uint32_t index, size_t length, void *user_arg, char *ch);
+
+int32_t jsmn_stream_token_utils_parse_with_cb(jsmn_stream_token_parser_t *parser, jsmn_stream_token_get_char_cb_t get_char_cb, size_t length, void *user_arg);
+int32_t jsmn_stream_token_utils_get_value_token_by_key(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *parent, uint32_t num_tokens, const char *key, jsmn_streamtok_t **value_token);
+int32_t jsmn_stream_token_utils_array_get_next_object_token(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *parent, jsmn_streamtok_t **iterator_token);
+int32_t jsmn_stream_token_utils_get_string_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token, char *buffer);
+int32_t jsmn_stream_token_utils_get_int_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  int32_t *value);
+int32_t jsmn_stream_token_utils_get_double_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  double *value);
+int32_t jsmn_stream_token_utils_get_bool_from_token(jsmn_stream_token_get_char_cb_t get_char_cb, void *user_arg, jsmn_streamtok_t *token,  bool *value);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* JSMN_STREAM_TOKEN_UTILS_H_ */

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,105 @@
+---
+
+# Notes:
+# Sample project C code is not presently written to produce a release artifact.
+# As such, release build options are disabled.
+# This sample, therefore, only demonstrates running a collection of unit tests.
+
+:project:
+  :use_exceptions: FALSE
+  :use_test_preprocessor: TRUE
+  :use_auxiliary_dependencies: TRUE
+  :build_root: build
+#  :release_build: TRUE
+  :test_file_prefix: test_
+  :which_ceedling: gem
+  :ceedling_version: 0.31.1
+  :default_tasks:
+    - test:all
+
+#:test_build:
+#  :use_assembly: TRUE
+
+#:release_build:
+#  :output: MyApp.out
+#  :use_assembly: FALSE
+
+:environment:
+
+:extension:
+  :executable: .out
+
+:paths:
+  :test:
+    - +:test/**
+    - -:test/support
+  :source:
+    - ./**
+  :support:
+    - test/support
+  :libraries: []
+
+:defines:
+  # in order to add common defines:
+  #  1) remove the trailing [] from the :common: section
+  #  2) add entries to the :common: section (e.g. :test: has TEST defined)
+  :common: &common_defines []
+  :test:
+    - *common_defines
+    - TEST
+    - UNITY_INCLUDE_DOUBLE
+  :test_preprocess:
+    - *common_defines
+    - TEST
+
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :callback
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+
+# Add -gcov to the plugins list to make sure of the gcov plugin
+# You will need to have gcov and gcovr both installed to make it work.
+# For more information on these options, see docs in plugins/gcov
+:gcov:
+  :reports:
+    - HtmlDetailed
+  :gcovr:
+    :html_medium_threshold: 75
+    :html_high_threshold: 90
+
+#:tools:
+# Ceedling defaults to using gcc for compiling, linking, etc.
+# As [:tools] is blank, gcc will be used (so long as it's in your system path)
+# See documentation to configure a given toolchain for use
+
+# LIBRARIES
+# These libraries are automatically injected into the build process. Those specified as
+# common will be used in all types of builds. Otherwise, libraries can be injected in just
+# tests or releases. These options are MERGED with the options in supplemental yaml files.
+:libraries:
+  :placement: :end
+  :flag: "-l${1}"
+  :path_flag: "-L ${1}"
+  :system: []    # for example, you might list 'm' to grab the math library
+  :test: []
+  :release: []
+
+:plugins:
+  :load_paths:
+    - "#{Ceedling.load_path}"
+  :enabled:
+    - gcov
+    - xml_tests_report
+    - stdout_gtestlike_tests_report
+    - module_generator
+    - raw_output_report
+...

--- a/test/test_jsmn_stream_token.c
+++ b/test/test_jsmn_stream_token.c
@@ -1,0 +1,293 @@
+#include "unity.h"
+#define JSMN_PARENT_LINKS
+#define JSMN_COMPATIBILITY_MODE 1
+
+/* The module to test */
+#include "jsmn_stream_token.h"
+#include "jsmn_stream.h"
+#include <string.h>
+
+
+const char* json_data =
+"{"
+    "\"glossary\": {"
+        "\"title\": \"example glossary\","
+        "\"GlossDiv\": {"
+            "\"title\": \"S\","
+            "\"GlossList\": {"
+                "\"GlossEntry\": {"
+                    "\"ID\": \"SGML\","
+                    "\"SortAs\": \"SGML\","
+                    "\"GlossTerm\": \"Standard Generalized Markup Language\","
+                    "\"Acronym\": \"SGML\","
+                    "\"Abbrev\": \"ISO 8879:1986\","
+                    "\"GlossDef\": {"
+                        "\"para\": \"A meta-markup language, used to create markup languages such as DocBook.\","
+                        "\"GlossSeeAlso\": [\"GML\", \"XML\"]"
+                    "},"
+                    "\"GlossSee\": \"markup\""
+                "}"
+            "}"
+        "}"
+    "}"
+"}";
+
+
+void setUp(void)
+{
+
+}
+
+void tearDown(void)
+{
+
+}
+
+void test_jsmn_stream_parse_tokens_init(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[32];
+
+    jsmn_stream_parse_tokens_init(&parser, tokens, 32);
+
+    TEST_ASSERT_EQUAL_PTR(tokens, parser.tokens);
+    TEST_ASSERT_EQUAL(0, parser.next_token);
+    TEST_ASSERT_EQUAL(32, parser.num_tokens);
+    TEST_ASSERT_EQUAL(0, parser.char_count);
+    TEST_ASSERT_EQUAL(-1, parser.super_token_id);
+    TEST_ASSERT_EQUAL_PTR(tokens, parser.tokens);
+    TEST_ASSERT_EQUAL_PTR(&parser, parser.stream_parser.user_arg);
+}
+
+int parse_tokens_helper(jsmn_stream_token_parser_t *parser, jsmn_streamtok_t *tokens, int num_tokens, char *json_data)
+{
+    char *p = json_data;
+
+    jsmn_stream_parse_tokens_init(parser, tokens, num_tokens);
+
+    for (int i = 0; i < strlen(json_data); i++)
+    {
+        jsmn_stream_parse_tokens(parser, *p++);
+        if (parser->error != JSMN_STREAM_TOKEN_ERROR_NONE)
+        {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+void test_empty_object(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[1];
+
+    parse_tokens_helper(&parser, tokens, 1, "{}");
+    
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+    TEST_ASSERT_EQUAL(0, tokens[0].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[0].type);
+    TEST_ASSERT_EQUAL(0, tokens[0].start);
+    TEST_ASSERT_EQUAL(2, tokens[0].end);
+    TEST_ASSERT_EQUAL(0, tokens[0].size);
+    TEST_ASSERT_EQUAL(-1, tokens[0].parent_id);
+}
+
+void test_empty_array(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[1];
+
+    parse_tokens_helper(&parser, tokens, 1, "[]");
+    
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+    TEST_ASSERT_EQUAL(0, tokens[0].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_ARRAY, tokens[0].type);
+    TEST_ASSERT_EQUAL(0, tokens[0].start);
+    TEST_ASSERT_EQUAL(2, tokens[0].end);
+    TEST_ASSERT_EQUAL(0, tokens[0].size);
+    TEST_ASSERT_EQUAL(-1, tokens[0].parent_id);
+}
+
+void test_array_with_two_empty_objects(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[3];
+
+    parse_tokens_helper(&parser, tokens, 3, "[{},{}]");
+    
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+    TEST_ASSERT_EQUAL(0, tokens[0].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_ARRAY, tokens[0].type);
+    TEST_ASSERT_EQUAL(0, tokens[0].start);
+    TEST_ASSERT_EQUAL(7, tokens[0].end);
+    TEST_ASSERT_EQUAL(2, tokens[0].size);
+    TEST_ASSERT_EQUAL(-1, tokens[0].parent_id);
+
+    TEST_ASSERT_EQUAL(1, tokens[1].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[1].type);
+    TEST_ASSERT_EQUAL(1, tokens[1].start);
+    TEST_ASSERT_EQUAL(3, tokens[1].end);
+    TEST_ASSERT_EQUAL(0, tokens[1].size);
+    TEST_ASSERT_EQUAL(0, tokens[1].parent_id);
+
+    TEST_ASSERT_EQUAL(2, tokens[2].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[2].type);
+    TEST_ASSERT_EQUAL(4, tokens[2].start);
+    TEST_ASSERT_EQUAL(6, tokens[2].end);
+    TEST_ASSERT_EQUAL(0, tokens[2].size);
+    TEST_ASSERT_EQUAL(0, tokens[2].parent_id);
+}
+
+void test_object_with_two_kv_pairs(void)
+{
+    char *json = "{\"key1\":\"value1\", \"key2\":\"value2\"}";
+
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[5];
+
+    parse_tokens_helper(&parser, tokens, 5, json);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+    TEST_ASSERT_EQUAL(0, tokens[0].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[0].type);
+    TEST_ASSERT_EQUAL(0, tokens[0].start);
+    TEST_ASSERT_EQUAL(34, tokens[0].end);
+    TEST_ASSERT_EQUAL(2, tokens[0].size);
+    TEST_ASSERT_EQUAL(-1, tokens[0].parent_id);
+
+    TEST_ASSERT_EQUAL(1, tokens[1].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[1].type);
+    TEST_ASSERT_EQUAL(2, tokens[1].start);
+    TEST_ASSERT_EQUAL(6, tokens[1].end);
+    TEST_ASSERT_EQUAL(1, tokens[1].size);
+    TEST_ASSERT_EQUAL(0, tokens[1].parent_id);
+
+    TEST_ASSERT_EQUAL(2, tokens[2].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_STRING, tokens[2].type);
+    TEST_ASSERT_EQUAL(9, tokens[2].start);
+    TEST_ASSERT_EQUAL(15, tokens[2].end);
+    TEST_ASSERT_EQUAL(0, tokens[2].size); 
+    TEST_ASSERT_EQUAL(1, tokens[2].parent_id);
+
+    TEST_ASSERT_EQUAL(3, tokens[3].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[3].type);
+    TEST_ASSERT_EQUAL(19, tokens[3].start);
+    TEST_ASSERT_EQUAL(23, tokens[3].end);
+    TEST_ASSERT_EQUAL(1, tokens[3].size);
+    TEST_ASSERT_EQUAL(0, tokens[3].parent_id);
+
+    TEST_ASSERT_EQUAL(4, tokens[4].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_STRING, tokens[4].type);
+    TEST_ASSERT_EQUAL(26, tokens[4].start);
+    TEST_ASSERT_EQUAL(32, tokens[4].end);
+    TEST_ASSERT_EQUAL(0, tokens[4].size);
+    TEST_ASSERT_EQUAL(3, tokens[4].parent_id);
+}
+
+void test_object_with_nested_objects(void)
+{
+    char *json = "{\"key1\":\"value1\", \"key2\":{\"key3\":\"value3\"}, \"key4\":\"value4\"}";
+
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[9];
+
+    parse_tokens_helper(&parser, tokens, 9, json);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+    TEST_ASSERT_EQUAL(0, tokens[0].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[0].type);
+    TEST_ASSERT_EQUAL(0, tokens[0].start);
+    TEST_ASSERT_EQUAL(60, tokens[0].end);
+    TEST_ASSERT_EQUAL(3, tokens[0].size);
+    TEST_ASSERT_EQUAL(-1, tokens[0].parent_id);
+
+    TEST_ASSERT_EQUAL(1, tokens[1].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[1].type);
+    TEST_ASSERT_EQUAL(2, tokens[1].start);
+    TEST_ASSERT_EQUAL(6, tokens[1].end);
+    TEST_ASSERT_EQUAL(1, tokens[1].size);
+    TEST_ASSERT_EQUAL(0, tokens[1].parent_id);
+
+    TEST_ASSERT_EQUAL(2, tokens[2].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_STRING, tokens[2].type);
+    TEST_ASSERT_EQUAL(9, tokens[2].start);
+    TEST_ASSERT_EQUAL(15, tokens[2].end);
+    TEST_ASSERT_EQUAL(0, tokens[2].size);
+    TEST_ASSERT_EQUAL(1, tokens[2].parent_id);
+
+    TEST_ASSERT_EQUAL(3, tokens[3].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[3].type);
+    TEST_ASSERT_EQUAL(19, tokens[3].start);
+    TEST_ASSERT_EQUAL(23, tokens[3].end);
+    TEST_ASSERT_EQUAL(1, tokens[3].size);
+    TEST_ASSERT_EQUAL(0, tokens[3].parent_id);
+
+    TEST_ASSERT_EQUAL(4, tokens[4].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[4].type);
+    TEST_ASSERT_EQUAL(25, tokens[4].start);
+    TEST_ASSERT_EQUAL(42, tokens[4].end);
+    TEST_ASSERT_EQUAL(1, tokens[4].size);
+    TEST_ASSERT_EQUAL(3, tokens[4].parent_id);
+
+    TEST_ASSERT_EQUAL(5, tokens[5].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[5].type);
+    TEST_ASSERT_EQUAL(27, tokens[5].start);
+    TEST_ASSERT_EQUAL(31, tokens[5].end);
+    TEST_ASSERT_EQUAL(1, tokens[5].size);
+    TEST_ASSERT_EQUAL(4, tokens[5].parent_id);
+
+    TEST_ASSERT_EQUAL(6, tokens[6].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_STRING, tokens[6].type);
+    TEST_ASSERT_EQUAL(34, tokens[6].start);
+    TEST_ASSERT_EQUAL(40, tokens[6].end);
+    TEST_ASSERT_EQUAL(0, tokens[6].size);
+    TEST_ASSERT_EQUAL(5, tokens[6].parent_id);
+
+    TEST_ASSERT_EQUAL(7, tokens[7].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_KEY, tokens[7].type);
+    TEST_ASSERT_EQUAL(45, tokens[7].start);
+    TEST_ASSERT_EQUAL(49, tokens[7].end);
+    TEST_ASSERT_EQUAL(1, tokens[7].size);
+    TEST_ASSERT_EQUAL(0, tokens[7].parent_id);
+
+    TEST_ASSERT_EQUAL(8, tokens[8].id);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_STRING, tokens[8].type);
+    TEST_ASSERT_EQUAL(52, tokens[8].start);
+    TEST_ASSERT_EQUAL(58, tokens[8].end);
+    TEST_ASSERT_EQUAL(0, tokens[8].size);
+    TEST_ASSERT_EQUAL(7, tokens[8].parent_id);
+
+}
+
+// ** These tests are not active. I used them to confirm
+// ** that the we get the same behaviour as the original
+// ** jsmn library. I'm leaving this here as a reference.
+
+// void check_tokens_match(jsmntok_t *jsmn, jsmn_streamtok_t *jsmn_stream)
+// {
+//     // TEST_ASSERT_EQUAL(jsmn->type, jsmn_stream->type);
+//     TEST_ASSERT_EQUAL(jsmn->start, jsmn_stream->start);
+//     TEST_ASSERT_EQUAL(jsmn->end, jsmn_stream->end);
+//     TEST_ASSERT_EQUAL(jsmn->size, jsmn_stream->size);
+//     TEST_ASSERT_EQUAL(jsmn->parent, jsmn_stream->parent);
+// }
+
+// void test_complex_example(void)
+// {
+//     jsmn_parser p;
+//     jsmntok_t t[100];
+
+//     jsmn_init(&p);
+//     int r = jsmn_parse(&p, json_data, strlen(json_data), t, 100);
+
+//     jsmn_stream_token_parser_t parser;
+//     jsmn_streamtok_t tokens[100];
+
+//     parse_tokens_helper(&parser, tokens, 100, json_data);
+
+//     TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, parser.error);
+//     TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, tokens[0].type);
+
+//     check_tokens_match(&t[0], &tokens[0]);
+// }

--- a/test/test_jsmn_stream_utils.c
+++ b/test/test_jsmn_stream_utils.c
@@ -1,0 +1,175 @@
+#include "unity.h"
+#define JSMN_PARENT_LINKS
+#define JSMN_COMPATIBILITY_MODE 1
+
+/* The module to test */
+#include "jsmn_stream_token_utils.h"
+#include "jsmn_stream_token.h"
+#include "jsmn_stream.h"
+#include <stdint.h>
+#include <string.h>
+
+const char* json_data = "{\n"
+    " \"operations\": [\n"
+    "    {\n"
+    "        \"id\": 1234,\n"
+    "        \"version\": 1,\n"
+    "        \"class\": \"pwm\",\n"
+    "        \"label\": \"instance of pwm\",\n"
+    "        \"operation properties\": \n"
+    "        {\n"
+    "            \"id\": \"PWMA\",\n"
+    "            \"period\": 50.5,\n"
+    "            \"polarity\": \"positive\"\n"
+    "        }\n"
+    "    },\n"
+    "    {\n"
+    "        \"id\": 5678,\n"
+    "        \"version\": 1,\n"
+    "        \"class\": \"gpio\",\n"
+    "        \"label\": \"instance of gpio\",\n"
+    "        \"operation properties\": \n"
+    "        {\n"
+    "            \"port\": \"A\",\n"
+    "            \"pin\": 1,\n"
+    "            \"enabled\": \"false\"\n"
+    "        }\n"
+    "    }\n"
+    " ]\n"
+"}";
+
+
+static int32_t get_char_cb(uint32_t index, size_t length, void *user_arg, char *ch)
+{
+    const char *data = (const char *)user_arg;
+    memcpy(ch, &data[index], length);
+    return 0;
+}
+
+void setUp(void)
+{
+
+}
+
+void tearDown(void)
+{
+
+}
+
+void test_jsmn_stream_token_utils_parse_with_cb_no_mem(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[30];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 30);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NOMEM, jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data));
+}
+
+void test_jsmn_stream_token_utils_parse_with_cb_success(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data));
+}
+
+/**
+ * @brief Key search is currently case sensitive.
+ * 
+ */
+void test_jsmn_stream_token_utils_get_value_token_by_key_not_found(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_UTILS_ERROR_KEY_NOT_FOUND, jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "ID", &value_token));
+}
+
+void test_jsmn_stream_token_utils_get_value_token_by_key_success(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "id", &value_token));
+}
+
+void test_jsmn_stream_token_utils_array_get_next_object_token_success(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *array_token = NULL;
+    jsmn_streamtok_t *iterator_token = NULL;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "operations", &array_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_array_get_next_object_token(&parser, array_token, &iterator_token));
+    TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, iterator_token->type);
+}
+
+void test_jsmn_stream_token_utils_get_string_from_token(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    char buffer[100] = {0};
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "class", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_string_from_token(cb, (void *)json_data, value_token, buffer));
+    TEST_ASSERT_EQUAL_STRING("pwm", buffer);
+}
+
+void test_jsmn_stream_token_utils_get_int_from_token(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    int32_t value;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "id", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_int_from_token(cb, (void *)json_data, value_token, &value));
+    TEST_ASSERT_EQUAL(1234, value);
+}
+
+void test_jsmn_stream_token_utils_get_double_from_token(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    double value;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "period", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_double_from_token(cb, (void *)json_data, value_token, &value));
+    TEST_ASSERT_EQUAL_DOUBLE(50.5, value);
+}
+
+void test_jsmn_stream_token_utils_get_bool_from_token(void)
+{
+    jsmn_stream_token_parser_t parser;
+    jsmn_streamtok_t tokens[100];
+    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
+    jsmn_streamtok_t *value_token;
+    bool value;
+    jsmn_stream_parse_tokens_init(&parser, tokens, 100);
+    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "enabled", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_bool_from_token(cb, (void *)json_data, value_token, &value));
+    TEST_ASSERT_EQUAL(false, value);
+}

--- a/test/test_jsmn_stream_utils.c
+++ b/test/test_jsmn_stream_utils.c
@@ -59,21 +59,23 @@ void tearDown(void)
 void test_jsmn_stream_token_utils_parse_with_cb_no_mem(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[30];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_stream_parse_tokens_init(&parser, tokens, 30);
 
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NOMEM, jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data));
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NOMEM, jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data));
 }
 
 void test_jsmn_stream_token_utils_parse_with_cb_success(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
 
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data));
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data));
 }
 
 /**
@@ -83,37 +85,40 @@ void test_jsmn_stream_token_utils_parse_with_cb_success(void)
 void test_jsmn_stream_token_utils_get_value_token_by_key_not_found(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
 
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_UTILS_ERROR_KEY_NOT_FOUND, jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "ID", &value_token));
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_UTILS_ERROR_KEY_NOT_FOUND, jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "ID", &value_token));
 }
 
 void test_jsmn_stream_token_utils_get_value_token_by_key_success(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
 
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "id", &value_token));
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "id", &value_token));
 }
 
 void test_jsmn_stream_token_utils_array_get_next_object_token_success(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *array_token = NULL;
     jsmn_streamtok_t *iterator_token = NULL;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
-    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "operations", &array_token);
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens,"operations", &array_token);
     TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_array_get_next_object_token(&parser, array_token, &iterator_token));
     TEST_ASSERT_EQUAL(JSMN_STREAM_OBJECT, iterator_token->type);
 }
@@ -121,55 +126,59 @@ void test_jsmn_stream_token_utils_array_get_next_object_token_success(void)
 void test_jsmn_stream_token_utils_get_string_from_token(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     char buffer[100] = {0};
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
-    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "class", &value_token);
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_string_from_token(cb, (void *)json_data, value_token, buffer));
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "class", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_string_from_token(&parser, value_token, buffer));
     TEST_ASSERT_EQUAL_STRING("pwm", buffer);
 }
 
 void test_jsmn_stream_token_utils_get_int_from_token(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     int32_t value;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
-    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "id", &value_token);
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_int_from_token(cb, (void *)json_data, value_token, &value));
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "id", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_int_from_token(&parser, value_token, &value));
     TEST_ASSERT_EQUAL(1234, value);
 }
 
 void test_jsmn_stream_token_utils_get_double_from_token(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     double value;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
-    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "period", &value_token);
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_double_from_token(cb, (void *)json_data, value_token, &value));
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "period", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_double_from_token(&parser, value_token, &value));
     TEST_ASSERT_EQUAL_DOUBLE(50.5, value);
 }
 
 void test_jsmn_stream_token_utils_get_bool_from_token(void)
 {
     jsmn_stream_token_parser_t parser;
+    parser.cb = get_char_cb;
+    parser.user_arg = (void *)json_data;
     jsmn_streamtok_t tokens[100];
-    jsmn_stream_token_get_char_cb_t cb = get_char_cb;
     jsmn_streamtok_t *value_token;
     bool value;
     jsmn_stream_parse_tokens_init(&parser, tokens, 100);
-    jsmn_stream_token_utils_parse_with_cb(&parser, cb, strlen(json_data), (void *)json_data);
-    jsmn_stream_token_utils_get_value_token_by_key(cb, (void *)json_data, tokens, 100, "enabled", &value_token);
-    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_bool_from_token(cb, (void *)json_data, value_token, &value));
+    jsmn_stream_token_utils_parse_with_cb(&parser, strlen(json_data), (void *)json_data);
+    jsmn_stream_token_utils_get_value_token_by_key(&parser, tokens, "enabled", &value_token);
+    TEST_ASSERT_EQUAL(JSMN_STREAM_TOKEN_ERROR_NONE, jsmn_stream_token_utils_get_bool_from_token(&parser, value_token, &value));
     TEST_ASSERT_EQUAL(false, value);
 }


### PR DESCRIPTION
I liked the tokenization provided by [jsmn](https://github.com/zserge/jsmn). I liked that jsmn-stream didn't require me to have the entire JSON file in RAM.

This is an extension on jsmn-stream that allows for tokenization similar to the original jsmn library. I tried to follow the format of the original jsmn code wherever possible.